### PR TITLE
Fix: Display the wrong product on the VirtusizeWebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ If you like, you can also customize the button style.
       product: _product,
       child: ElevatedButton(
         child: Text('Custom Button'), 
-        // Implement the `OnPressed` callback with the `VirtusizePlugin.instance.openVirtusizeWebView` function if you have customized the button
-        onPressed: VirtusizeSDK.instance.openVirtusizeWebView
+        // Implement the `onPressed` callback with the `VirtusizePlugin.instance.openVirtusizeWebView` function if you have customized the button
+        onPressed: () => VirtusizeSDK.instance.openVirtusizeWebView(_product))
       )
   )
   ```

--- a/android/src/main/kotlin/com/virtusize/virtusize_flutter_sdk/VirtusizeFlutterConstants.kt
+++ b/android/src/main/kotlin/com/virtusize/virtusize_flutter_sdk/VirtusizeFlutterConstants.kt
@@ -7,8 +7,6 @@ internal object VirtusizeFlutterMethod {
     const val GET_RECOMMENDATION_TEXT = "getRecommendationText"
     const val GET_PRIVACY_POLICY_LINK = "getPrivacyPolicyLink"
     const val SEND_ORDER = "sendOrder"
-    const val ADD_PRODUCT = "addProduct"
-    const val REMOVE_PRODUCT = "removeProduct"
 
     // Android to Flutter
     const val ON_VS_EVENT = "onVSEvent"

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -90,8 +90,8 @@ class _HomeScreenState extends State<HomeScreen> {
                             borderRadius:
                                 BorderRadius.all(Radius.circular(32.0)))),
 
-                    /// Implement the [OnPressed] callback with the [VirtusizePlugin.instance.openVirtusizeWebView] function if you have customized the button
-                    onPressed: VirtusizeSDK.instance.openVirtusizeWebView),
+                    /// Implement the [onPressed] callback with the [VirtusizePlugin.instance.openVirtusizeWebView] function if you have customized the button
+                    onPressed: () => VirtusizeSDK.instance.openVirtusizeWebView(_product))
               )),
               Container(height: 16),
 

--- a/ios/Classes/VirtusizeFlutterConstants.swift
+++ b/ios/Classes/VirtusizeFlutterConstants.swift
@@ -7,8 +7,6 @@ struct VirtusizeFlutterMethod {
 	static let getRecommendationText = "getRecommendationText"
 	static let getPrivacyPolicyLink = "getPrivacyPolicyLink"
 	static let sendOrder = "sendOrder"
-	static let addProduct = "addProduct"
-	static let removeProduct = "removeProduct"
 	
 	/// iOS to Flutter
 	static let onVSEvent = "onVSEvent"

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -185,10 +185,10 @@ class VirtusizeSDK {
   }
 
   /// A function for clients to open the Virtusize webview (only when they customize their own button using the [VirtusizeButton] widget)
-  Future<void> openVirtusizeWebView() async {
+  Future<void> openVirtusizeWebView(VirtusizeClientProduct product) async {
     try {
       await IVirtusizeSDK.instance._channel
-          .invokeMethod(FlutterVirtusizeMethod.openVirtusizeWebView);
+          .invokeMethod(FlutterVirtusizeMethod.openVirtusizeWebView, product.externalProductId);
     } on PlatformException catch (error) {
       print('Failed to open the VirtusizeWebView: $error');
     }
@@ -257,29 +257,6 @@ class IVirtusizeSDK {
     } on PlatformException catch (error) {
       print('Failed to get the privacy policy link: $error');
       return null;
-    }
-  }
-
-  /// A function to add a product ID to the (external) Product ID stack in Native.
-  /// The most recently visited product will be at the top of the stack.
-  Future<void> addProduct({@required String externalProductId}) async {
-    if (externalProductId == null) {
-      return;
-    }
-    try {
-      await _channel.invokeMethod(
-          FlutterVirtusizeMethod.addProduct, externalProductId);
-    } on PlatformException catch (error) {
-      print('Failed to add the product $externalProductId: $error');
-    }
-  }
-
-  /// A function to remove the most recent visited external product ID from the stack in Native
-  Future<void> removeProduct() async {
-    try {
-      await _channel.invokeMethod(FlutterVirtusizeMethod.removeProduct);
-    } on PlatformException catch (error) {
-      print('Failed to remove a product $error');
     }
   }
 }

--- a/lib/src/utils/virtusize_constants.dart
+++ b/lib/src/utils/virtusize_constants.dart
@@ -7,8 +7,6 @@ class FlutterVirtusizeMethod {
   static const String getRecommendationText = "getRecommendationText";
   static const String getPrivacyPolicyLink = "getPrivacyPolicyLink";
   static const String sendOrder = "sendOrder";
-  static const String addProduct = "addProduct";
-  static const String removeProduct = "removeProduct";
 
   // Native to Flutter
   static const String onVSEvent = "onVSEvent";

--- a/lib/src/widgets/virtusize_button.dart
+++ b/lib/src/widgets/virtusize_button.dart
@@ -48,8 +48,6 @@ class _VirtusizeButtonState extends State<VirtusizeButton> {
       if (widget.product.externalProductId != productDataCheck.externalProductId) {
         return;
       }
-      IVirtusizeSDK.instance
-          .addProduct(externalProductId: productDataCheck.externalProductId);
       setState(() {
         _isValidProduct = productDataCheck.isValidProduct;
       });
@@ -58,7 +56,6 @@ class _VirtusizeButtonState extends State<VirtusizeButton> {
 
   @override
   void dispose() {
-    IVirtusizeSDK.instance.removeProduct();
     _vsTextSubscription.cancel();
     _pdcSubscription.cancel();
     super.dispose();
@@ -85,7 +82,7 @@ class _VirtusizeButtonState extends State<VirtusizeButton> {
   }
 
   Future<void> _openVirtusizeWebview() async {
-    await VirtusizeSDK.instance.openVirtusizeWebView();
+    await VirtusizeSDK.instance.openVirtusizeWebView(widget.product);
   }
 
   ElevatedButton _buildVSButton(Color color, Widget child) {

--- a/lib/src/widgets/virtusize_inpage_mini.dart
+++ b/lib/src/widgets/virtusize_inpage_mini.dart
@@ -54,8 +54,6 @@ class _VirtusizeInPageMiniState extends State<VirtusizeInPageMini> {
       if (widget.product.externalProductId != pdc.externalProductId) {
         return;
       }
-      IVirtusizeSDK.instance
-          .addProduct(externalProductId: pdc.externalProductId);
       setState(() {
         _isLoading = true;
         _hasError = false;
@@ -82,7 +80,6 @@ class _VirtusizeInPageMiniState extends State<VirtusizeInPageMini> {
 
   @override
   void dispose() {
-    IVirtusizeSDK.instance.removeProduct();
     _vsTextSubscription.cancel();
     _pdcSubscription.cancel();
     _recSubscription.cancel();
@@ -101,7 +98,7 @@ class _VirtusizeInPageMiniState extends State<VirtusizeInPageMini> {
   }
 
   Future<void> _openVirtusizeWebview() async {
-    await VirtusizeSDK.instance.openVirtusizeWebView();
+    await VirtusizeSDK.instance.openVirtusizeWebView(widget.product);
   }
 
   Widget _buildVSInPageMini() {

--- a/lib/src/widgets/virtusize_inpage_standard.dart
+++ b/lib/src/widgets/virtusize_inpage_standard.dart
@@ -64,8 +64,6 @@ class _VirtusizeInPageStandardState extends State<VirtusizeInPageStandard> {
       if (widget.product.externalProductId != pdc.externalProductId) {
         return;
       }
-      IVirtusizeSDK.instance
-          .addProduct(externalProductId: pdc.externalProductId);
       setState(() {
         _isLoading = true;
         _hasError = false;
@@ -142,7 +140,6 @@ class _VirtusizeInPageStandardState extends State<VirtusizeInPageStandard> {
 
   @override
   void dispose() {
-    IVirtusizeSDK.instance.removeProduct();
     _vsTextSubscription.cancel();
     _pdcSubscription.cancel();
     _productSubscription.cancel();
@@ -159,7 +156,7 @@ class _VirtusizeInPageStandardState extends State<VirtusizeInPageStandard> {
   }
 
   Future<void> _openVirtusizeWebview() async {
-    await VirtusizeSDK.instance.openVirtusizeWebView();
+    await VirtusizeSDK.instance.openVirtusizeWebView(widget.product);
   }
 
   Future<void> _openPrivacyPolicyLink() async {


### PR DESCRIPTION
Now that each widget is bound with the VirtusizeClientProduct data. We only need passing the externalProductId from Flutter to Native to know which product to be loaded on the Virtusize web view instead of tracking the most recent visited product by a stack.
